### PR TITLE
refactor: tornar mensagens de erro amigáveis em pt-br

### DIFF
--- a/src/app/api/capsules/[capsuleId]/upload/route.ts
+++ b/src/app/api/capsules/[capsuleId]/upload/route.ts
@@ -20,7 +20,10 @@ export async function POST(
     const title = formData.get('title') as string
 
     if (!file || file.size === 0) {
-      return NextResponse.json({ error: 'File is required' }, { status: 400 })
+      return NextResponse.json(
+        { error: 'Selecione uma foto ou vídeo para enviar.' },
+        { status: 400 }
+      )
     }
 
     let mediaUrl = ''
@@ -53,6 +56,9 @@ export async function POST(
     return NextResponse.json({ success: true, message })
   } catch (error) {
     console.error('Upload error:', error)
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json(
+      { error: 'Ocorreu um erro ao enviar sua mensagem. Tente novamente.' },
+      { status: 500 }
+    )
   }
 }

--- a/src/app/api/media/route.ts
+++ b/src/app/api/media/route.ts
@@ -19,7 +19,10 @@ export async function GET(request: NextRequest) {
   const storagePath = request.nextUrl.searchParams.get('path');
 
   if (!storagePath) {
-    return NextResponse.json({ error: 'Missing media path' }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Caminho da mídia não informado.' },
+      { status: 400 }
+    );
   }
 
   const downloadUrl = await storageProvider.getDownloadUrl(storagePath);

--- a/src/components/upload-form.tsx
+++ b/src/components/upload-form.tsx
@@ -82,7 +82,15 @@ export function UploadForm({ capsuleId }: UploadFormProps) {
         body: formData,
       })
 
-      if (!response.ok) throw new Error('Upload failed')
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        const errorMessage =
+          typeof data?.error === 'string' && data.error.trim().length > 0
+            ? data.error
+            : 'Não foi possível enviar sua mensagem agora. Tente novamente em instantes.'
+
+        throw new Error(errorMessage)
+      }
 
       toast.success('Mensagem enviada com sucesso!')
       // Reset form
@@ -90,7 +98,12 @@ export function UploadForm({ capsuleId }: UploadFormProps) {
       setPreview(null)
     } catch (error) {
       console.error(error)
-      toast.error('Erro ao enviar mensagem. Tente novamente.')
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Não foi possível enviar sua mensagem agora. Tente novamente em instantes.'
+
+      toast.error(message)
     } finally {
       setIsUploading(false)
     }


### PR DESCRIPTION
### Motivation
- Melhorar a experiência do usuário ao tornar as mensagens de erro da aplicação mais claras e em português brasileiro.
- Garantir que mensagens retornadas pela API sejam exibidas no cliente para fornecer feedback específico ao usuário.

### Description
- No endpoint de upload (`src/app/api/capsules/[capsuleId]/upload/route.ts`) a mensagem para arquivo ausente foi traduzida para `Selecione uma foto ou vídeo para enviar.` e a mensagem de erro interno foi traduzida para `Ocorreu um erro ao enviar sua mensagem. Tente novamente.`.
- No endpoint de mídia (`src/app/api/media/route.ts`) a validação do parâmetro `path` agora retorna `Caminho da mídia não informado.` quando ausente.
- No formulário de upload cliente (`src/components/upload-form.tsx`) o código agora tenta ler `response.json()` em respostas não-ok e exibe a chave `error` retornada pela API via `toast`, com um fallback amigável em português caso a resposta não contenha JSON válido.
- Nenhuma alteração de schema ou variáveis de ambiente foi feita; arquivos modificados: the three files above.

### Testing
- Executei `npm run lint` e o lint passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12a6901088329b2a96d9a66ed4257)