### PR TITLE
test: add coverage for upload and media flows

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,36 @@
+name: PR Tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+concurrency:
+  group: pr-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/src/app/api/capsules/[capsuleId]/upload/init/route.test.ts
+++ b/src/app/api/capsules/[capsuleId]/upload/init/route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storageMocks = vi.hoisted(() => ({
+  createPresignedUpload: vi.fn(),
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storageProvider: {
+    createPresignedUpload: storageMocks.createPresignedUpload,
+  },
+}))
+
+import { POST } from './route'
+
+describe('POST /api/capsules/[capsuleId]/upload/init', () => {
+  beforeEach(() => {
+    storageMocks.createPresignedUpload.mockReset()
+  })
+
+  it('returns 400 when originalFilename or mimeType is missing', async () => {
+    const request = new Request('http://localhost/api/capsules/test/upload/init', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        originalFilename: 'photo.jpg',
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'originalFilename and mimeType are required',
+    })
+    expect(storageMocks.createPresignedUpload).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the upload metadata fails validation', async () => {
+    const request = new Request('http://localhost/api/capsules/test/upload/init', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        originalFilename: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        fileSize: 50 * 1024 * 1024 + 1,
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'O arquivo deve ter no maximo 50MB.',
+    })
+    expect(storageMocks.createPresignedUpload).not.toHaveBeenCalled()
+  })
+
+  it('returns directUpload false when the storage provider does not support presigned uploads', async () => {
+    storageMocks.createPresignedUpload.mockResolvedValue(null)
+
+    const request = new Request('http://localhost/api/capsules/test/upload/init', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        originalFilename: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        fileSize: 1024,
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      directUpload: false,
+    })
+    expect(storageMocks.createPresignedUpload).toHaveBeenCalledWith('photo.jpg', 'image/jpeg')
+  })
+
+  it('returns the presigned upload target when direct upload is available', async () => {
+    storageMocks.createPresignedUpload.mockResolvedValue({
+      uploadUrl: 'https://storage.example/upload',
+      storagePath: 'capsules/test/photo.jpg',
+      mediaType: 'IMAGE',
+    })
+
+    const request = new Request('http://localhost/api/capsules/test/upload/init', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        originalFilename: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        fileSize: 1024,
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      directUpload: true,
+      uploadUrl: 'https://storage.example/upload',
+      storagePath: 'capsules/test/photo.jpg',
+      mediaType: 'IMAGE',
+    })
+  })
+
+  it('returns 500 when creating the upload target throws', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    storageMocks.createPresignedUpload.mockRejectedValue(new Error('storage offline'))
+
+    const request = new Request('http://localhost/api/capsules/test/upload/init', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        originalFilename: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        fileSize: 1024,
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Internal Server Error',
+    })
+    expect(consoleError).toHaveBeenCalledWith(
+      'Upload init error:',
+      expect.any(Error)
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/app/api/capsules/[capsuleId]/upload/route.test.ts
+++ b/src/app/api/capsules/[capsuleId]/upload/route.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { POST } from './route'
+
+type UploadRouteRequest = {
+  cookies: {
+    get: (name: string) => { value: string } | undefined
+  }
+  formData: () => Promise<FormData>
+}
+
+const prismaMocks = vi.hoisted(() => ({
+  messageCreate: vi.fn(),
+}))
+
+const storageMocks = vi.hoisted(() => ({
+  upload: vi.fn(),
+}))
+
+const accessMocks = vi.hoisted(() => ({
+  getCapsuleAccessConfig: vi.fn(),
+  hasValidAccessCookie: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    message: {
+      create: prismaMocks.messageCreate,
+    },
+  },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storageProvider: {
+    upload: storageMocks.upload,
+  },
+}))
+
+vi.mock('@/lib/capsule-access/config', () => ({
+  getCapsuleAccessConfig: accessMocks.getCapsuleAccessConfig,
+}))
+
+vi.mock('@/lib/capsule-access/cookie', () => ({
+  ACCESS_COOKIE_NAME: 'wedding_guest_access',
+  hasValidAccessCookie: accessMocks.hasValidAccessCookie,
+}))
+
+
+function createRequest(
+  entries: Array<[string, string | File]>,
+  cookieValue?: string
+): UploadRouteRequest {
+  const formData = new FormData()
+
+  for (const [key, value] of entries) {
+    formData.set(key, value)
+  }
+
+  return {
+    cookies: {
+      get: vi.fn((name: string) =>
+        name === 'wedding_guest_access' && cookieValue
+          ? { value: cookieValue }
+          : undefined
+      ),
+    },
+    formData: vi.fn().mockResolvedValue(formData),
+  }
+}
+
+function createParams() {
+  return Promise.resolve({ capsuleId: 'capsule-123' })
+}
+
+describe('POST /api/capsules/[capsuleId]/upload', () => {
+  beforeEach(() => {
+    prismaMocks.messageCreate.mockReset()
+    storageMocks.upload.mockReset()
+    accessMocks.getCapsuleAccessConfig.mockReset()
+    accessMocks.hasValidAccessCookie.mockReset()
+
+    accessMocks.getCapsuleAccessConfig.mockReturnValue(null)
+    accessMocks.hasValidAccessCookie.mockResolvedValue(false)
+    prismaMocks.messageCreate.mockResolvedValue({
+      id: 'message-1',
+      capsuleId: 'capsule-123',
+    })
+    storageMocks.upload.mockResolvedValue({
+      storagePath: 'capsules/capsule-123/photo.jpg',
+      mediaType: 'IMAGE',
+    })
+  })
+
+  it('returns 403 when the capsule is protected and the access cookie is invalid', async () => {
+    accessMocks.getCapsuleAccessConfig.mockReturnValue({
+      inviteToken: 'invite-token',
+      cookieSecret: 'cookie-secret',
+    })
+    accessMocks.hasValidAccessCookie.mockResolvedValue(false)
+
+    const request = createRequest([])
+
+    const response = await POST(
+      request as unknown as Parameters<typeof POST>[0],
+      { params: createParams() }
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Access denied',
+    })
+    expect(accessMocks.hasValidAccessCookie).toHaveBeenCalledWith(
+      undefined,
+      'cookie-secret'
+    )
+    expect(request.formData).not.toHaveBeenCalled()
+    expect(prismaMocks.messageCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when neither a direct upload nor a file upload is provided', async () => {
+    const request = createRequest([
+      ['sender', 'Alice'],
+      ['content', 'Parabens!'],
+      ['title', 'Memoria'],
+    ])
+
+    const response = await POST(
+      request as unknown as Parameters<typeof POST>[0],
+      { params: createParams() }
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Selecione uma foto ou vídeo para enviar.',
+    })
+    expect(storageMocks.upload).not.toHaveBeenCalled()
+    expect(prismaMocks.messageCreate).not.toHaveBeenCalled()
+  })
+
+  it('persists a direct upload when the access cookie is valid', async () => {
+    accessMocks.getCapsuleAccessConfig.mockReturnValue({
+      inviteToken: 'invite-token',
+      cookieSecret: 'cookie-secret',
+    })
+    accessMocks.hasValidAccessCookie.mockResolvedValue(true)
+    prismaMocks.messageCreate.mockResolvedValue({
+      id: 'message-2',
+      capsuleId: 'capsule-123',
+      mediaUrl: 'capsules/capsule-123/video.mp4',
+      type: 'VIDEO',
+    })
+
+    const request = createRequest(
+      [
+        ['mediaPath', 'capsules/capsule-123/video.mp4'],
+        ['mediaType', 'VIDEO'],
+        ['sender', 'Alice'],
+        ['content', 'Uma lembranca especial'],
+        ['title', 'Nosso video'],
+      ],
+      'signed-cookie'
+    )
+
+    const response = await POST(
+      request as unknown as Parameters<typeof POST>[0],
+      { params: createParams() }
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      message: {
+        id: 'message-2',
+        capsuleId: 'capsule-123',
+        mediaUrl: 'capsules/capsule-123/video.mp4',
+        type: 'VIDEO',
+      },
+    })
+    expect(accessMocks.hasValidAccessCookie).toHaveBeenCalledWith(
+      'signed-cookie',
+      'cookie-secret'
+    )
+    expect(storageMocks.upload).not.toHaveBeenCalled()
+    expect(prismaMocks.messageCreate).toHaveBeenCalledWith({
+      data: {
+        sender: 'Alice',
+        content: 'Uma lembranca especial',
+        title: 'Nosso video',
+        mediaUrl: 'capsules/capsule-123/video.mp4',
+        type: 'VIDEO',
+        capsuleId: 'capsule-123',
+      },
+    })
+  })
+
+  it('returns 400 when the uploaded file fails media validation', async () => {
+    const file = new File(['document'], 'notes.pdf', {
+      type: 'application/pdf',
+    })
+    const request = createRequest([['file', file]])
+
+    const response = await POST(
+      request as unknown as Parameters<typeof POST>[0],
+      { params: createParams() }
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Apenas imagens e vídeos suportados são permitidos.',
+    })
+    expect(storageMocks.upload).not.toHaveBeenCalled()
+    expect(prismaMocks.messageCreate).not.toHaveBeenCalled()
+  })
+
+  it('uploads the file to storage and creates the message record', async () => {
+    prismaMocks.messageCreate.mockResolvedValue({
+      id: 'message-3',
+      capsuleId: 'capsule-123',
+      mediaUrl: 'capsules/capsule-123/photo.jpg',
+      type: 'IMAGE',
+    })
+
+    const file = new File(['image-bytes'], 'photo.jpg', {
+      type: 'image/jpeg',
+    })
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: vi
+        .fn()
+        .mockResolvedValue(new TextEncoder().encode('image-bytes').buffer),
+    })
+    const request = createRequest([
+      ['file', file],
+      ['sender', 'Bob'],
+      ['content', 'Te amo'],
+    ])
+
+    const response = await POST(
+      request as unknown as Parameters<typeof POST>[0],
+      { params: createParams() }
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      message: {
+        id: 'message-3',
+        capsuleId: 'capsule-123',
+        mediaUrl: 'capsules/capsule-123/photo.jpg',
+        type: 'IMAGE',
+      },
+    })
+    expect(storageMocks.upload).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      'photo.jpg',
+      'image/jpeg'
+    )
+    expect(prismaMocks.messageCreate).toHaveBeenCalledWith({
+      data: {
+        sender: 'Bob',
+        content: 'Te amo',
+        title: null,
+        mediaUrl: 'capsules/capsule-123/photo.jpg',
+        type: 'IMAGE',
+        capsuleId: 'capsule-123',
+      },
+    })
+  })
+
+  it('returns 500 when an unexpected error happens during persistence', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    prismaMocks.messageCreate.mockRejectedValue(new Error('database offline'))
+
+    const request = createRequest([
+      ['mediaPath', 'capsules/capsule-123/photo.jpg'],
+      ['mediaType', 'IMAGE'],
+    ])
+
+    const response = await POST(
+      request as unknown as Parameters<typeof POST>[0],
+      { params: createParams() }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Ocorreu um erro ao enviar sua mensagem. Tente novamente.',
+    })
+    expect(consoleError).toHaveBeenCalledWith(
+      'Upload error:',
+      expect.any(Error)
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/app/api/media/route.test.ts
+++ b/src/app/api/media/route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const storageMocks = vi.hoisted(() => ({
+  getDownloadUrl: vi.fn(),
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storageProvider: {
+    getDownloadUrl: storageMocks.getDownloadUrl,
+  },
+}))
+
+import { GET } from './route'
+
+function createRequest(url: string, headers?: HeadersInit) {
+  return {
+    nextUrl: new URL(url),
+    headers: new Headers(headers),
+  } as NextRequest
+}
+
+describe('GET /api/media', () => {
+  const originalStorageProvider = process.env.STORAGE_PROVIDER
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    storageMocks.getDownloadUrl.mockReset()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+
+    if (originalStorageProvider === undefined) {
+      delete process.env.STORAGE_PROVIDER
+    } else {
+      process.env.STORAGE_PROVIDER = originalStorageProvider
+    }
+  })
+
+  it('returns 400 when the media path is missing', async () => {
+    const request = createRequest('http://localhost/api/media')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.any(String),
+      })
+    )
+    expect(storageMocks.getDownloadUrl).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects to the storage asset when the provider is cloudinary', async () => {
+    process.env.STORAGE_PROVIDER = 'cloudinary'
+    storageMocks.getDownloadUrl.mockResolvedValue('https://cdn.example/capsules/photo.jpg')
+
+    const request = createRequest('http://localhost/api/media?path=capsules/photo.jpg')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://cdn.example/capsules/photo.jpg')
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=86400, stale-while-revalidate=604800'
+    )
+    expect(response.headers.get('cdn-cache-control')).toBeNull()
+    expect(storageMocks.getDownloadUrl).toHaveBeenCalledWith('capsules/photo.jpg')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('proxies partial upstream responses for non-cloudinary providers', async () => {
+    process.env.STORAGE_PROVIDER = 'backblaze'
+    storageMocks.getDownloadUrl.mockResolvedValue('https://storage.example/capsules/video.mp4')
+    fetchMock.mockResolvedValue(
+      new Response('partial-media', {
+        status: 206,
+        headers: {
+          'accept-ranges': 'bytes',
+          'content-length': '12',
+          'content-range': 'bytes 0-11/120',
+          'content-type': 'video/mp4',
+          etag: '"asset-tag"',
+          'last-modified': 'Tue, 22 Apr 2025 10:00:00 GMT',
+          'x-extra-header': 'ignored',
+        },
+      })
+    )
+
+    const request = createRequest('http://localhost/api/media?path=capsules/video.mp4', {
+      range: 'bytes=0-11',
+    })
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(206)
+    await expect(response.text()).resolves.toBe('partial-media')
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=3500, stale-while-revalidate=60'
+    )
+    expect(response.headers.get('cdn-cache-control')).toBe(
+      'public, s-maxage=86400, stale-while-revalidate=604800'
+    )
+    expect(response.headers.get('vercel-cdn-cache-control')).toBe(
+      'public, s-maxage=86400, stale-while-revalidate=604800'
+    )
+    expect(response.headers.get('content-range')).toBe('bytes 0-11/120')
+    expect(response.headers.get('content-type')).toBe('video/mp4')
+    expect(response.headers.get('x-extra-header')).toBeNull()
+    expect(storageMocks.getDownloadUrl).toHaveBeenCalledWith('capsules/video.mp4')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [downloadUrl, init] = fetchMock.mock.calls[0]
+    expect(downloadUrl).toBe('https://storage.example/capsules/video.mp4')
+    expect(init?.cache).toBe('no-store')
+    expect(init?.headers).toBeInstanceOf(Headers)
+  })
+
+  it('returns the upstream error status when fetching the media asset fails', async () => {
+    process.env.STORAGE_PROVIDER = 'backblaze'
+    storageMocks.getDownloadUrl.mockResolvedValue('https://storage.example/capsules/photo.jpg')
+    fetchMock.mockResolvedValue(
+      new Response('not found', {
+        status: 404,
+      })
+    )
+
+    const request = createRequest('http://localhost/api/media?path=capsules/photo.jpg')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to fetch media asset',
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://storage.example/capsules/photo.jpg',
+      expect.objectContaining({
+        cache: 'no-store',
+      })
+    )
+  })
+})

--- a/src/components/formatted-date.test.tsx
+++ b/src/components/formatted-date.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { FormattedDate } from './formatted-date'
+
+describe('FormattedDate', () => {
+  it('renders the formatted date text', () => {
+    render(<FormattedDate date={new Date(2025, 2, 15, 9, 30)} />)
+
+    expect(screen.getByText(/15\/03\/2025/)).toBeInTheDocument()
+    expect(screen.getByText(/09:30/)).toBeInTheDocument()
+  })
+})

--- a/src/lib/capsule-access/config.test.ts
+++ b/src/lib/capsule-access/config.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getCapsuleAccessConfig,
+  isProtectedCapsuleRoute,
+} from './config'
+
+describe('capsule-access/config', () => {
+  beforeEach(() => {
+    vi.stubEnv('CAPSULE_ACCESS_TOKEN', undefined)
+    vi.stubEnv('CAPSULE_ACCESS_COOKIE_SECRET', undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('marks capsule routes as protected', () => {
+    expect(isProtectedCapsuleRoute('/capsules/abc')).toBe(true)
+    expect(isProtectedCapsuleRoute('/capsules/abc/share')).toBe(true)
+  })
+
+  it('does not mark unrelated routes as protected', () => {
+    expect(isProtectedCapsuleRoute('/')).toBe(false)
+    expect(isProtectedCapsuleRoute('/api/media')).toBe(false)
+  })
+
+  it('returns null when the invite token is not configured', () => {
+    expect(getCapsuleAccessConfig()).toBeNull()
+  })
+
+  it('uses the invite token as the fallback cookie secret', () => {
+    vi.stubEnv('CAPSULE_ACCESS_TOKEN', 'invite-token')
+
+    expect(getCapsuleAccessConfig()).toEqual({
+      inviteToken: 'invite-token',
+      cookieSecret: 'invite-token',
+    })
+  })
+
+  it('uses the explicit cookie secret when provided', () => {
+    vi.stubEnv('CAPSULE_ACCESS_TOKEN', 'invite-token')
+    vi.stubEnv('CAPSULE_ACCESS_COOKIE_SECRET', 'cookie-secret')
+
+    expect(getCapsuleAccessConfig()).toEqual({
+      inviteToken: 'invite-token',
+      cookieSecret: 'cookie-secret',
+    })
+  })
+})

--- a/src/lib/capsule-access/cookie.test.ts
+++ b/src/lib/capsule-access/cookie.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ACCESS_COOKIE_MAX_AGE_SECONDS,
+  ACCESS_COOKIE_NAME,
+  createAccessCookie,
+  hasValidAccessCookie,
+} from './cookie'
+
+describe('capsule-access/cookie', () => {
+  const secret = 'super-secret'
+  const baseTime = new Date('2026-04-22T12:00:00.000Z')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(baseTime)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('creates a signed cookie that validates with the same secret', async () => {
+    const cookie = await createAccessCookie(secret, true)
+
+    expect(cookie).toMatchObject({
+      name: ACCESS_COOKIE_NAME,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+      path: '/',
+      maxAge: ACCESS_COOKIE_MAX_AGE_SECONDS,
+    })
+    expect(await hasValidAccessCookie(cookie.value, secret)).toBe(true)
+  })
+
+  it('rejects a cookie signed with a different secret', async () => {
+    const cookie = await createAccessCookie(secret, false)
+
+    expect(await hasValidAccessCookie(cookie.value, 'different-secret')).toBe(false)
+  })
+
+  it('rejects malformed cookie values', async () => {
+    expect(await hasValidAccessCookie(undefined, secret)).toBe(false)
+    expect(await hasValidAccessCookie('invalid', secret)).toBe(false)
+    expect(await hasValidAccessCookie('denied.123.signature', secret)).toBe(false)
+  })
+
+  it('rejects expired cookies even when the signature matches', async () => {
+    const cookie = await createAccessCookie(secret, false)
+
+    vi.advanceTimersByTime((ACCESS_COOKIE_MAX_AGE_SECONDS + 1) * 1000)
+
+    expect(await hasValidAccessCookie(cookie.value, secret)).toBe(false)
+  })
+})

--- a/src/lib/media.test.ts
+++ b/src/lib/media.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMediaAssetUrl } from './media'
+
+describe('getMediaAssetUrl', () => {
+  it('returns an empty string when there is no storage path', () => {
+    expect(getMediaAssetUrl('')).toBe('')
+  })
+
+  it('builds the API url with an encoded path query parameter', () => {
+    expect(getMediaAssetUrl('capsules/our photo.png')).toBe(
+      '/api/media?path=capsules%2Four+photo.png'
+    )
+  })
+})

--- a/src/lib/upload-validation.test.ts
+++ b/src/lib/upload-validation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_FILE_SIZE,
+  getMediaValidationError,
+  isAcceptedFileSize,
+  isAcceptedMediaType,
+} from './upload-validation'
+
+describe('upload-validation', () => {
+  it('accepts supported image and video mime types', () => {
+    expect(isAcceptedMediaType('image/jpeg')).toBe(true)
+    expect(isAcceptedMediaType('video/mp4')).toBe(true)
+  })
+
+  it('rejects unsupported mime types', () => {
+    expect(isAcceptedMediaType('application/pdf')).toBe(false)
+  })
+
+  it('accepts files up to the maximum size limit', () => {
+    expect(isAcceptedFileSize(MAX_FILE_SIZE)).toBe(true)
+    expect(isAcceptedFileSize(MAX_FILE_SIZE + 1)).toBe(false)
+  })
+
+  it('returns the file size error before the mime type error', () => {
+    const error = getMediaValidationError('application/pdf', MAX_FILE_SIZE + 1)
+
+    expect(error).toMatch(/50MB/)
+  })
+
+  it('returns a mime type error for unsupported files within the size limit', () => {
+    const error = getMediaValidationError('application/pdf', MAX_FILE_SIZE)
+
+    expect(error).toMatch(/permitidos/)
+  })
+
+  it('returns null for valid media files', () => {
+    expect(getMediaValidationError('image/png', MAX_FILE_SIZE)).toBeNull()
+  })
+})

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { cn, formatDateTime } from './utils'
+
+describe('utils', () => {
+  it('merges class names and resolves tailwind conflicts', () => {
+    expect(cn('px-2', false, 'px-4', ['text-sm'])).toBe('px-4 text-sm')
+  })
+
+  it('formats a date with both date and time information', () => {
+    const result = formatDateTime(new Date(2025, 2, 15, 9, 30))
+
+    expect(result).toMatch(/15\/03\/2025/)
+    expect(result).toMatch(/09:30/)
+  })
+})


### PR DESCRIPTION
## Summary
- add Vitest coverage for capsule upload init, upload, and media API routes
- add unit tests for capsule access helpers, media helpers, upload validation, and shared utils
- add a component test for formatted date rendering

## Verification
- `npm.cmd run lint`
- `npm.cmd test` (35 tests passing)

## Notes
- no schema or environment changes
